### PR TITLE
Fix for #17 - Provide additional information

### DIFF
--- a/src/SC2Balance/Controllers/DataController.cs
+++ b/src/SC2Balance/Controllers/DataController.cs
@@ -75,8 +75,15 @@ namespace SC2Balance.Controllers
         {
             using (var db = new DataContext())
             {
-                var lastUpdated = db.ProcessingRuns.OrderByDescending(r => r.Id).First().DateTime;
-                return (int)TimeSpan.FromTicks(DateTime.UtcNow.Ticks - lastUpdated.Ticks).TotalHours;
+                try
+                {
+                    var lastUpdated = db.ProcessingRuns.OrderByDescending(r => r.Id).First().DateTime;
+                    return (int) TimeSpan.FromTicks(DateTime.UtcNow.Ticks - lastUpdated.Ticks).TotalHours;
+                }
+                catch (InvalidOperationException)
+                {
+                    throw new ApplicationException("No ProcessingRuns currently loaded. Run the IngestAndProcessRunner, then the ProcessRunner to load the database before viewing the webpage.");
+                }
             }
         }
 


### PR DESCRIPTION
When first loading the webpage, database may not have any data in it,
this provides additional details on how to load the data.

https://github.com/sc2balance/SC2Balance/issues/17

I rethrew the error with additional data because this will occur very
rarely and be seen only by developers. No need for a pretty screen.
